### PR TITLE
Add feature flags for cron and jobs functionality

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(cargo check:*)",
       "Bash(cargo clippy:*)",
       "Bash(gh pr view:*)",
-      "Bash(rg:*)"
+      "Bash(rg:*)",
+      "Bash(gh pr comment:*)"
     ],
     "deny": []
   }

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -12,8 +12,21 @@ env:
 
 jobs:
   check:
-    name: Check (${{ inputs.rust-version }})
+    name: Check (${{ inputs.rust-version }}, ${{ matrix.features-name }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - features-name: "all"
+            features-args: "--all-features"
+          - features-name: "default"
+            features-args: ""
+          - features-name: "no-default"
+            features-args: "--no-default-features"
+          - features-name: "jobs-only"
+            features-args: "--no-default-features --features jobs"
+          - features-name: "cron-only"
+            features-args: "--no-default-features --features cron"
 
     services:
       postgres:
@@ -45,11 +58,11 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets ${{ matrix.features-args }} -- -D warnings
         continue-on-error: ${{ inputs.rust-version == 'nightly' }}
 
       - name: Build
-        run: cargo build --all-targets --all-features
+        run: cargo build --all-targets ${{ matrix.features-args }}
 
       - name: Run tests
-        run: cargo test --all-targets --all-features
+        run: cargo test --all-targets ${{ matrix.features-args }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .env
 .envrc
+.claude/settings.local.json

--- a/crates/cja.app/Cargo.toml
+++ b/crates/cja.app/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 
+[features]
+default = ["cron", "jobs"]
+cron = ["cja/cron"]
+jobs = ["cja/jobs"]
+
 [dependencies]
 cja = { path = "../cja" }
 

--- a/crates/cja.app/Cargo.toml
+++ b/crates/cja.app/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 
 [features]
 default = ["cron", "jobs"]
-cron = ["cja/cron"]
+cron = ["cja/cron", "jobs"]
 jobs = ["cja/jobs"]
 
 [dependencies]

--- a/crates/cja.app/src/main.rs
+++ b/crates/cja.app/src/main.rs
@@ -205,7 +205,7 @@ fn spawn_application_tasks(
     } else {
         info!("Jobs Disabled");
     }
-    
+
     #[cfg(not(feature = "jobs"))]
     {
         info!("Jobs feature not compiled in");
@@ -219,7 +219,7 @@ fn spawn_application_tasks(
     } else {
         info!("Cron Disabled");
     }
-    
+
     #[cfg(not(feature = "cron"))]
     {
         info!("Cron feature not compiled in");
@@ -263,9 +263,9 @@ mod cron {
     use cja::cron::{CronRegistry, Worker};
 
     #[cfg(feature = "jobs")]
-    use std::time::Duration;
-    #[cfg(feature = "jobs")]
     use crate::jobs::NoopJob;
+    #[cfg(feature = "jobs")]
+    use std::time::Duration;
 
     use super::AppState;
 

--- a/crates/cja/Cargo.toml
+++ b/crates/cja/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 
 [features]
 default = ["cron", "jobs"]
-cron = []
+cron = ["jobs"]
 jobs = []
 
 [dependencies]

--- a/crates/cja/Cargo.toml
+++ b/crates/cja/Cargo.toml
@@ -4,6 +4,11 @@ description = "Cron, Jobs and Axum a meta-framework for building web application
 edition.workspace = true
 authors.workspace = true
 
+[features]
+default = ["cron", "jobs"]
+cron = []
+jobs = []
+
 [dependencies]
 async-trait.workspace = true
 axum.workspace = true

--- a/crates/cja/src/cron/registry.rs
+++ b/crates/cja/src/cron/registry.rs
@@ -3,7 +3,9 @@ use std::{collections::HashMap, error::Error, future::Future, pin::Pin, time::Du
 use chrono::{OutOfRangeError, Utc};
 use tracing::error;
 
-use crate::{app_state::AppState as AS, jobs::Job};
+use crate::app_state::AppState as AS;
+#[cfg(feature = "jobs")]
+use crate::jobs::Job;
 
 pub struct CronRegistry<AppState: AS> {
     pub(super) jobs: HashMap<&'static str, CronJob<AppState>>,
@@ -148,6 +150,7 @@ impl<AppState: AS> CronRegistry<AppState> {
         self.jobs.insert(name, cron_job);
     }
 
+    #[cfg(feature = "jobs")]
     #[tracing::instrument(name = "cron.register_job", skip_all, fields(cron_job.name = J::NAME, cron_job.interval = ?interval))]
     pub fn register_job<J: Job<AppState>>(&mut self, job: J, interval: Duration) {
         self.register(J::NAME, interval, move |app_state, context| {

--- a/crates/cja/src/lib.rs
+++ b/crates/cja/src/lib.rs
@@ -1,7 +1,9 @@
 pub use sqlx;
 pub use uuid;
 
+#[cfg(feature = "cron")]
 pub mod cron;
+#[cfg(feature = "jobs")]
 pub mod jobs;
 pub mod server;
 


### PR DESCRIPTION
## Summary
- Added Cargo feature flags to allow disabling cron and jobs functionality at compile time
- Both features are enabled by default to maintain backward compatibility
- Updated GitHub Actions to test all feature flag combinations

## Changes

### Feature Flags
- Added `cron` and `jobs` features to `cja/Cargo.toml` with both enabled by default
- Added matching features to `cja.app/Cargo.toml` that depend on the cja crate features

### Conditional Compilation
- Made cron and jobs modules conditionally compiled based on their respective features
- Added conditional imports where cron depends on jobs functionality
- Updated the example app to handle all feature combinations correctly

### Testing
- Added matrix strategy to GitHub Actions workflow to test:
  - All features enabled
  - Default features (same as all currently)
  - No features
  - Jobs only
  - Cron only

## Benefits
- Consumers can now opt out of cron/jobs functionality if not needed
- Reduces binary size and dependencies for users who don't need these features
- Maintains full backward compatibility with default features

## Test plan
- [x] Verified compilation with all feature combinations locally
- [ ] CI will test all combinations via the new matrix build
- [ ] No runtime behavior changes when features are enabled

🤖 Generated with [Claude Code](https://claude.ai/code)